### PR TITLE
prevent "<" and ">" from appearing in a shell cmd

### DIFF
--- a/lumail2.lua
+++ b/lumail2.lua
@@ -1258,10 +1258,7 @@ ${sig}
 
         -- Replace the recipient, if present.
         cmd = string.interp(cmd, {
-            recipient = to,
-
-
-
+            recipient = to:match("<(.*)>") or to,
           })
 
         -- Run the command.
@@ -1388,7 +1385,6 @@ function Message.send_reply (include_cc)
       to = result
     end
   end
-
 
   --
   -- Get the subject of the message.
@@ -1633,10 +1629,7 @@ References: ${references}
 
         -- Replace the recipient, if present.
         cmd = string.interp(cmd, {
-            recipient = to,
-
-
-
+            recipient = to:match("<(.*)>") or to,
           })
 
         -- Run the command.
@@ -1902,10 +1895,7 @@ Begin forwarded message.
 
         -- Replace the recipient, if present.
         cmd = string.interp(cmd, {
-            recipient = to,
-
-
-
+            recipient = to:match("<(.*)>") or to,
           })
 
         -- Run the command.


### PR DESCRIPTION
When I want to answer with an encrypted mail I got the error from sh that the file `some@mail.tld` can't be found.

This PR strips the full name from `Someone <some@mail.tld>` and only
passes the email on.

I think this is only useful when answering but it doesn't hurt in the other
cases.
