### PR TITLE
Configurable defaults for gpg 

### DIFF
--- a/API.md
+++ b/API.md
@@ -174,6 +174,10 @@ displays things, these are:
 * `maildir.truncate`
     * Alternate between showing the full/truncated Maildir path in maildir-mode.
 
+The default behaviour of the gpg support can be configured with:
+
+* `gpg,mode`
+    * For further information [see](GPG.md).
 
 
 ### Directories

--- a/GPG.md
+++ b/GPG.md
@@ -7,6 +7,7 @@ Lumail now contains (experimental) support for GPG, which covers:
 * Decrypting messages.
 * Encryting outgoing email.
 * Signing outgoing email.
+* Configurable default behavior.
 
 All of this GPG-support is implemented via the use of the `mimegpg` tool, which is part of the courier mail-server.  Upon a Debian GNU/Linux system the binary can be found by installing the sqwebmail package:
 
@@ -75,3 +76,11 @@ You can choose to sign your outgoing messages, encrypt your outgoing messages, o
 In the case of encryption the recipient's email will be used to determine the key to use.
 
 To enable this just press `g` when prompted and then make your selection.
+
+Configuration
+-------------
+
+You can set the config value `gpg.mode` to eather always or auto(recommended).
+
+* always - Always sign and encrypt. WARNING: This can break easily.
+* auto   - Sign and encrypt only if the recipients key is in your keyring.

--- a/lib/gpg.lua
+++ b/lib/gpg.lua
@@ -70,3 +70,41 @@ _G['message_replace'] = function (path)
     return ""
   end
 end
+
+local gpg = {}
+
+--
+-- Prompt for gpg options
+--
+gpg.prompt = function(options)
+  gpg = Screen:prompt("(c)ancel, (n)othing, (s)ign, (e)ncryt, or (b)oth?", "nNcCsSeEbB")
+  if (gpg == "c") or (gpg == "C") then
+    return options
+  elseif (gpg == "n") or (gpg == "N") then
+    return ""
+  elseif (gpg == "s") or (gpg == "S") then
+    return "-s"
+  elseif (gpg == "e") or (gpg == "E") then
+    return "-E -- --batch -r ${recipient} --trust-model always"
+  elseif (gpg == "b") or (gpg == "b") then
+    return"-s -E -- --batch -r ${recipient} --trust-model always"
+  end
+end
+
+--
+-- Sign or encrypt a mail
+--
+gpg.prepare_mail = function(mail, options, recipient)
+  local tmp2 = os.tmpname()
+  -- Build up the command
+  local cmd = "mimegpg " .. options .. "< " .. mail .. " > " .. tmp2
+  -- Replace the recipient, if present.
+  cmd = string.interp(cmd, { recipient = recipient:match("<(.*)>") or recipient, })
+  -- Run the command.
+  os.execute(cmd)
+   -- Now replace the temporary file we're to use
+  File:copy(tmp2, mail)
+  os.remove(tmp2)
+end
+
+return gpg

--- a/lib/gpg.lua
+++ b/lib/gpg.lua
@@ -141,7 +141,7 @@ end
 --
 -- Invoke mimegpg and replace the mail with its output
 --
-gpg.mimgpg_replace = function(mail, options, recipient)
+gpg.replace_mail = function(mail, options, recipient)
   local tmp = os.tmpname()
 
   -- Build up the command.
@@ -151,12 +151,18 @@ gpg.mimgpg_replace = function(mail, options, recipient)
   cmd = string.interp(cmd, { recipient = recipient:match("<(.*)>") or recipient, })
 
   -- Run the command.
-  -- TODO Handle errors better. E.g. capture and present stderr.
-  os.execute(cmd)
+  -- TODO capture and present stderr.
+  if os.execute(cmd) then
+    -- Replace the mail with our temporary file.
+    os.remove(mail)
+    return tmp
+  else
+    error_msg("GPG: mimegpg failed")
+    -- Mimegpg failed. Clean up our tmp file and return the old mail
+    os.remove(tmp)
+    return mail
+  end
 
-  -- Replace the mail with our temporary file.
-  File:copy(tmp, mail)
-  os.remove(tmp)
 end
 
 return gpg

--- a/lumail2.lua
+++ b/lumail2.lua
@@ -82,6 +82,7 @@ GPG = nil
 if string.path "mimegpg" then
   GPG = require "gpg"
 end
+Panel:append(GPG)
 
 
 --
@@ -1225,19 +1226,7 @@ ${sig}
       if GPG == nil then
         warning_msg "GPG support disabled!"
       else
-        local gpg = Screen:prompt("(c)ancel, (s)ign, (e)encryt, or (b)oth?", "cCsSeEbB")
-        if (gpg == "c") or (gpg == "C") then
-          encrypt = ""
-        end
-        if (gpg == "s") or (gpg == "S") then
-          encrypt = "-s"
-        end
-        if (gpg == "e") or (gpg == "E") then
-          encrypt = "-E -- --batch -r ${recipient} --trust-model always"
-        end
-        if (gpg == "b") or (gpg == "b") then
-          encrypt = "-s -E -- --batch -r ${recipient} --trust-model always"
-        end
+        encrypt = GPG.prompt(encrypt)
       end
     end
 
@@ -1258,24 +1247,8 @@ ${sig}
       -- If the user has encryption options then do the necessary
       --
       if encrypt ~= "" then
-        local tmp2 = os.tmpname()
-
-        -- Build up the command
-        local cmd = "mimegpg " .. encrypt .. "< " .. tmp .. " > " .. tmp2
-
-        -- Replace the recipient, if present.
-        cmd = string.interp(cmd, {
-            recipient = to:match("<(.*)>") or to,
-          })
-
-        -- Run the command.
-        os.execute(cmd)
-
-        -- Now replace the temporary file we're to use
-        File:copy(tmp2, tmp)
-        os.remove(tmp2)
+        GPG.prepare_mail(tmp, encrypt, to)
       end
-
 
       -- Allow transformations to occur before sending the message.
       if type(on_message_send) == "function" then
@@ -1596,19 +1569,7 @@ References: ${references}
       if GPG == nil then
         warning_msg "GPG support disabled!"
       else
-        local gpg = Screen:prompt("(c)ancel, (s)ign, (e)encryt, or (b)oth?", "cCsSeEbB")
-        if (gpg == "c") or (gpg == "C") then
-          encrypt = ""
-        end
-        if (gpg == "s") or (gpg == "S") then
-          encrypt = "-s"
-        end
-        if (gpg == "e") or (gpg == "E") then
-          encrypt = "-E -- --batch -r ${recipient} --trust-model always"
-        end
-        if (gpg == "b") or (gpg == "b") then
-          encrypt = "-s -E -- --batch -r ${recipient} --trust-model always"
-        end
+        encrypt = GPG.prompt(encrypt)
       end
     end
 
@@ -1629,22 +1590,7 @@ References: ${references}
       -- If the user has encryption options then do the necessary
       --
       if encrypt ~= "" then
-        local tmp2 = os.tmpname()
-
-        -- Build up the command
-        local cmd = "mimegpg " .. encrypt .. "< " .. tmp .. " > " .. tmp2
-
-        -- Replace the recipient, if present.
-        cmd = string.interp(cmd, {
-            recipient = to:match("<(.*)>") or to,
-          })
-
-        -- Run the command.
-        os.execute(cmd)
-
-        -- Now replace the temporary file we're to use
-        File:copy(tmp2, tmp)
-        os.remove(tmp2)
+        GPG.prepare_mail(tmp, encrypt, to)
       end
 
       -- Allow transformations to occur before sending the message.
@@ -1862,19 +1808,7 @@ Begin forwarded message.
       if GPG == nil then
         warning_msg "GPG support disabled!"
       else
-        local gpg = Screen:prompt("(c)ancel, (s)ign, (e)encryt, or (b)oth?", "cCsSeEbB")
-        if (gpg == "c") or (gpg == "C") then
-          encrypt = ""
-        end
-        if (gpg == "s") or (gpg == "S") then
-          encrypt = "-s"
-        end
-        if (gpg == "e") or (gpg == "E") then
-          encrypt = "-E -- --batch -r ${recipient} --trust-model always"
-        end
-        if (gpg == "b") or (gpg == "b") then
-          encrypt = "-s -E -- --batch -r ${recipient} --trust-model always"
-        end
+        encrypt = GPG.prompt(encrypt)
       end
     end
 
@@ -1895,22 +1829,7 @@ Begin forwarded message.
       -- If the user has encryption options then do the necessary
       --
       if encrypt ~= "" then
-        local tmp2 = os.tmpname()
-
-        -- Build up the command
-        local cmd = "mimegpg " .. encrypt .. "< " .. tmp .. " > " .. tmp2
-
-        -- Replace the recipient, if present.
-        cmd = string.interp(cmd, {
-            recipient = to:match("<(.*)>") or to,
-          })
-
-        -- Run the command.
-        os.execute(cmd)
-
-        -- Now replace the temporary file we're to use
-        File:copy(tmp2, tmp)
-        os.remove(tmp2)
+        GPG.prepare_mail(tmp, encrypt, to)
       end
 
       -- Allow transformations to occur before sending the message.

--- a/lumail2.lua
+++ b/lumail2.lua
@@ -1251,7 +1251,7 @@ ${sig}
       -- If the user has encryption options then do the necessary
       --
       if encrypt ~= "" then
-        GPG.prepare_mail(tmp, encrypt, to)
+        tmp = GPG.replace_mail(tmp, encrypt, to)
       end
 
       -- Allow transformations to occur before sending the message.
@@ -1596,7 +1596,7 @@ References: ${references}
       -- If the user has encryption options then do the necessary
       --
       if encrypt ~= "" then
-        GPG.prepare_mail(tmp, encrypt, to)
+        tmp = GPG.replace_mail(tmp, encrypt, to)
       end
 
       -- Allow transformations to occur before sending the message.
@@ -1838,7 +1838,7 @@ Begin forwarded message.
       -- If the user has encryption options then do the necessary
       --
       if encrypt ~= "" then
-        GPG.prepare_mail(tmp, encrypt, to)
+        tmp = GPG.replace_mail(tmp, encrypt, to)
       end
 
       -- Allow transformations to occur before sending the message.

--- a/lumail2.lua
+++ b/lumail2.lua
@@ -1210,6 +1210,10 @@ ${sig}
 
   -- GPG options
   local encrypt = ""
+  if GPG ~= nil then
+    -- Get the default options
+    encrypt = GPG.defaults(to)
+  end
 
   while run do
 
@@ -1552,7 +1556,9 @@ References: ${references}
 
   -- GPG options
   local encrypt = ""
-
+  if GPG ~= nil then
+    encrypt = GPG.defaults(to)
+  end
 
   while run do
 
@@ -1792,6 +1798,9 @@ Begin forwarded message.
 
   -- GPG options
   local encrypt = ""
+  if GPG ~= nil then
+    encrypt = GPG.defaults(to)
+  end
 
   while run do
 


### PR DESCRIPTION
When I fixed the gpg error in reply I realised that our gpg support is scattered over many functions. So the first commit extracts duplicated gpg code into lib/gpg.lua.

The second commit adds a new config value `gpg.mode` which sets the gpg options without
user interaction. The behavior is documented in the code, the commit and GPG.md.

Some questions:

* Is it ok to use lumail specific functionality in a library ? (`Config:get`, `Screen:prompt`)
* Is it ok to present information to the user in a library ? (`info_msg`,`error_msg`)

I think this is mergeable. What do you think ?
**EDIT:** Now it is mergeable :)

Other possible gpg improvements would be:

- [ ] Capture stderr of mimegpg, so it does not mess up the interface
- [X] Don't replace the mail if mimegpg failed
- [X] Don't copy the file just override the handle