### PR TITLE
fix gpg.defaults

### DIFF
--- a/lib/gpg.lua
+++ b/lib/gpg.lua
@@ -112,8 +112,8 @@ gpg.defaults = function(recipient)
     return gpg.mimegpg_args("b")
   elseif mode == "auto" then
     -- Check if a key is available for the recipients mail address
-    recipient = recipient:match("(<.*>)") or recipient
-    local has_gpg = os.execute(string.format("gpg --list-keys | grep -q %s", recipient))
+    recipient = recipient:match("<(.*)>") or recipient
+    local has_gpg = os.execute(string.format("gpg --list-keys | grep -q '%s'", recipient))
     if has_gpg then
       return gpg.mimegpg_args("b")
     else


### PR DESCRIPTION
The regex to extract the recipients email address was wrong.

This and the fact that the recipients email wasn't quoted in the shell command
leaded to a bug and a serious security vulnerability.
