### PR TITLE
rename lumail2.lua to global.config.lua

### DIFF
--- a/API.md
+++ b/API.md
@@ -97,7 +97,7 @@ the value of a key is changed.  The function will be given two arguments:
 * The name of the key which has changed-value.
 * The previous value of that key, if any.
 
-**NOTE**: We've defined a helper method in `lumail2.lua` which allows you to retrieve the value of a configuration-key and return a default value if the key is not set.
+**NOTE**: We've defined a helper method in `global.config.lua` which allows you to retrieve the value of a configuration-key and return a default value if the key is not set.
 
       function Config.get_with_default(key,default)
           ..

--- a/HACKING.md
+++ b/HACKING.md
@@ -3,7 +3,7 @@
 
 The core of lumail is written in C++, with extensive Lua support.
 
-The main Lua code, used for configuration, is located in the `lumail2.lua`
+The main Lua code, used for configuration, is located in the `global.config.lua`
 file, with a number of supporting libraries located beneath `lib/`.
 
 The C++ code can all be found beneath the top-level `src/` directory.

--- a/Makefile
+++ b/Makefile
@@ -269,4 +269,4 @@ install: lumail2 install_imap install_lua
 #  Test for leaks; use the debug-build so we get line-number information, etc.
 #
 valgrind: lumail2-debug
-	valgrind  --leak-check=full --show-leak-kinds=all --track-origins=yes ./lumail2-debug  --load-file ./lumail2.lua 2>leak.log
+	valgrind  --leak-check=full --show-leak-kinds=all --track-origins=yes ./lumail2-debug  --load-file ./global.config.lua 2>leak.log


### PR DESCRIPTION
Some files still mention `lumail2.lua` even the Makefile.