### PR TITLE
Improve threading

### DIFF
--- a/global.config.lua
+++ b/global.config.lua
@@ -603,51 +603,8 @@ function sort_messages (input)
   --
   if method == "threads" then
     local t_start = os.time()
-    local threads = Threader.thread(input)
-
-    --
-    -- Signs used to indent threads
-    --
-    local threads_output_signs = Config.get_with_default("threads.output", " ;`;-> ")
-    threads_output_signs = threads_output_signs:gmatch "([^;]+)"
-    local threads_output_indent = threads_output_signs()
-    local threads_output_root = threads_output_signs()
-    local threads_output_sign = threads_output_signs()
-
-    --
-    -- Sort threads
-    --
-    local sort_method = Config:get "threads.sort"
-    if sort_method and type(_G["compare_by_" .. sort_method]) == "function" then
-      threads = Threader.sort(threads, _G["compare_by_" .. sort_method], "max")
-    end
-
-    --
-    -- helper to recursively traverse the tree
-    --
-    local function thread_walk (c, col, i, i_col)
-      if c.message then
-        table.insert(col, c.message)
-        i_col[c.message] = i
-        if i == "" then
-          i = threads_output_root .. threads_output_sign
-        end
-        i = threads_output_indent .. i
-      else
-        i = threads_output_sign
-      end
-      for _, child in ipairs(c.children) do
-        thread_walk(child, col, i, i_col)
-      end
-    end
-
-    -- flat list of containers
     local res = {}
-
-    for _, c in ipairs(threads) do
-      thread_walk(c, res, "", threads_indentation)
-    end
-
+    res, threads_indentation = Threader.thread(input)
     local t_end = os.time()
     Panel:append("Sort method $[WHITE|BOLD]" .. method .. "$[WHITE] took $[WHITE|BOLD]" .. (t_end - t_start) .. "$[WHITE] seconds with " .. "$[WHITE|BOLD]" .. #input .. "$[WHITE] messages")
 

--- a/lib/threader.lua
+++ b/lib/threader.lua
@@ -642,7 +642,21 @@ end
 -- Jump to the next thread
 --
 function Threader.next_thread()
-  Threader.iterate_thread(nil, next)
+  -- call next till we reach a root
+  local msgs = get_messages()
+  local index = Config:get("index.current") + 1
+
+  -- Do we start with a root ?
+  if Threader.roots[msgs[index]] then
+    next()
+    index = index + 1
+  end
+
+  
+  while Threader.roots[msgs[index]] == nil do
+    next()
+    index = index + 1
+  end
 end
 
 --

--- a/lib/threader.lua
+++ b/lib/threader.lua
@@ -278,15 +278,15 @@ Threader.overridden = {}
 --
 -- Table that holds valuable information about our threads.
 -- It associates every root message with its thread number and
--- holds every root message ordered in the indexed part of the table.
+-- holds an ordered list of root messages in the indexed part of the table.
 --
 --
--- Threader.roots[some_root_message]     gives us the number of the thread which is
---                                       started by some_root_message.
+-- Threader.roots[some_root_message]       gives us the number of the thread
+--                                         which is started by some_root_message.
 --
--- Threader.roots[some_non_root_message] will return nil.
+-- Threader.roots[some_non_root_message]   will return nil.
 --
--- Threader.roots[1]                     gives us the root message of the first thread.
+-- Threader.roots[1]                       gives us the root message of the first thread.
 --
 -- This information empowers us to use thread aware functions on a flat thread-sorted
 -- table of messages.
@@ -296,8 +296,8 @@ Threader.roots = {}
 --
 --- Thread messages.
 --
--- This function returns a flat list of messages and a list of thread indentation.
--- It also generate the information in Threader.roots.
+-- Return a flat list of messages and a list of thread indentation.
+-- Also generate the information in Threader.roots.
 --
 function Threader.thread (messages)
   -- build up the threads
@@ -470,7 +470,7 @@ function Threader.thread (messages)
   end
 
   --
-  -- Populate the hash side of the roots table
+  -- Populate Threader.roots
   --
   for i,c in ipairs(roots) do
     local msg = c.message
@@ -570,10 +570,9 @@ end
 
 --
 -- Iterate through the whole thread the current message is in.
--- msg_callback is called once on each message.
--- general_callback is called once per iteration.
+-- msg_callback is called on each message.
 --
--- It returns the frames of the iterated thread: the roots of current and next thread.
+-- Return the frames of the iterated thread: the roots of current and next thread.
 --
 function Threader.iterate_thread(msg_callback, general_callback)
 
@@ -607,9 +606,6 @@ function Threader.iterate_thread(msg_callback, general_callback)
   if msg_callback then
     msg_callback(root)
   end
-  if general_callback then
-    general_callback()
-  end
 
   -- find next thread
   index = index + 1
@@ -617,9 +613,6 @@ function Threader.iterate_thread(msg_callback, general_callback)
   while Threader.roots[msg] == nil do
     if msg_callback then
       msg_callback(msg)
-    end
-    if general_callback then
-      general_callback()
     end
     index = index + 1
     msg = msgs[index]


### PR DESCRIPTION
This pull request adds thread aware functions, like `next_thread` or `thread_mark_read`.

`thread_next` mentioned in #317 is not implemented because we only have the thread information when `index.sort == "threads"` and then the next message in a thread is above the current one. So it would be useless.

The thread awareness is achieved by storing an array of root messages.

I didn't add default keybindings yet.

What do you think ?