### PR TITLE
fix completion if only one option is available

### DIFF
--- a/global.config.lua
+++ b/global.config.lua
@@ -3824,12 +3824,14 @@ do
       return ""
     end
 
+    local choice = ""
     -- Only one completion?
     if #completions == 1 then
-       return completions[1]
+       choice = completions[1]
+    else
+      choice = Screen:choose_string(completions)
     end
 
-    local choice = Screen:choose_string(completions)
     if choice ~= "" then
       -- Build the buffer to return
       local token = tokens[index[choice]]


### PR DESCRIPTION
I am totaly sorry for the trouble you have with the new completions and the code quality. :(

If you want to keep them here is a patch to fix completion if only one is available.
The solution used in c++ and mentioned in #330 is not correct.