### PR TITLE
[WIP] improve gpg

### DIFF
--- a/global.config.lua
+++ b/global.config.lua
@@ -2384,15 +2384,12 @@ function Message:format (thread_indent, index)
   -- unrelated to the flags a message might have.
   --
   --   A => Message has attachments.
-  --   S => Message is signed.
+  --   G => Message is signed or encrypted.
   --
-  local m_flags = ""
+  local m_flags = self:need_gpg() and "G" or ""
   local parts = mimeparts2table(self)
   local a_count = 0
   for i, o in ipairs(parts) do
-    if o['type'] == "text/x-gpg-output" then
-      m_flags = m_flags .. "S"
-    end
     if o['filename'] ~= nil and o['filename'] ~= "" then
       a_count = a_count + 1
     end
@@ -2929,12 +2926,15 @@ function message_view (msg)
   end
 
   if not msg then
-    return {
-      "No message selected!",
+    return "No message selected!"
+  end
 
-
-
-    }
+  -- Replace the message if its encrypted or signed
+  if msg:need_gpg() then
+    local tmpfile = GPG.decrypt(msg:path())
+    if tmpfile ~= "" then
+      msg:replace(tmpfile)
+    end
   end
 
   --

--- a/lib/gpg.lua
+++ b/lib/gpg.lua
@@ -1,4 +1,20 @@
 --
+-- Decrypt the message into a temporary file and return its path.
+--
+local decrypt = function(path)
+  --
+  -- Do we have the binary we want?
+  --
+  if string.path "mimegpg" ~= "" then
+    local out = os.tmpname()
+    os.execute("mimegpg -d -c -- --batch < " .. path .. " > " .. out)
+    return out
+  else
+    return ""
+  end
+end
+
+--
 -- This is a function which is inserted into the *MIDDLE*
 -- of a message parsing operation.
 --
@@ -21,7 +37,7 @@
 --
 -- OR
 --
---  * THis function may generate and return a filename.  That file
+--  * This function may generate and return a filename.  That file
 --    will be operated upon instead of the input message, and once
 --    parsed will be deleted.
 --
@@ -59,22 +75,16 @@ _G['message_replace'] = function (path)
   if found == false then
     return ""
   end
-  --
-  -- Do we have the binary we want?
-  --
-  if string.path "mimegpg" ~= "" then
-    local out = os.tmpname()
-    os.execute("mimegpg -d -c -- --batch < " .. path .. " > " .. out)
-    return out
-  else
-    return ""
-  end
+  return decrypt(path)
 end
+
 
 --
 -- GPG module
 --
 local gpg = {}
+
+gpg.decrypt = decrypt
 
 --
 -- Return the arguments for mimegpg

--- a/src/message.h
+++ b/src/message.h
@@ -78,6 +78,11 @@ public:
     void path(std::string new_path);
 
     /**
+     * Replace the message.
+     */
+    void replace(std::string new_path);
+
+    /**
      * Get the value of the given header.
      */
     std::string header(std::string name);
@@ -193,6 +198,11 @@ public:
      */
     int get_mtime();
 
+    /**
+     * Does this message need gpg ?
+     */
+    bool need_gpg();
+
 private:
 
     /**
@@ -252,6 +262,12 @@ private:
      * The parent folder.
      */
     std::shared_ptr<CMaildir> m_parent;
+
+    /**
+     * Is this message signed or encrypted
+     */
+    bool m_need_gpg;
+
 };
 
 

--- a/src/message_lua.cc
+++ b/src/message_lua.cc
@@ -148,6 +148,22 @@ int l_CMessage_path(lua_State * l)
     return 1;
 }
 
+/**
+ * Implementation for Message:replace()
+ */
+int l_CMessage_replace(lua_State * l)
+{
+    CLuaLog("l_CMessage_replace");
+
+    std::shared_ptr<CMessage> msg = l_CheckCMessage(l, 1);
+    const char *str = luaL_checkstring(l, 2);
+
+    if (msg)
+        msg->replace(str);
+
+    return 0;
+}
+
 
 /**
  * Implementation for Message:generate_message_id()
@@ -315,7 +331,7 @@ int l_CMessage_parts(lua_State * l)
 
 
 /**
- * Implementation of CMessage:add_attachments
+ * Implementation for CMessage:add_attachments()
  */
 int l_CMessage_add_attachments(lua_State * l)
 {
@@ -350,7 +366,7 @@ int l_CMessage_add_attachments(lua_State * l)
 
 
 /**
- * Implementation of CMessage:ctime()
+ * Implementation for CMessage:ctime()
  */
 int l_CMessage_ctime(lua_State * l)
 {
@@ -386,7 +402,7 @@ int l_CMessage_ctime(lua_State * l)
 
 
 /**
- * Implementation of CMessage:flags
+ * Implementation for CMessage:flags()
  */
 int l_CMessage_flags(lua_State * l)
 {
@@ -458,7 +474,7 @@ int l_CMessage_equality(lua_State * l)
 
 
 /**
- * Implementation of CMessage:unlink
+ * Implementation for CMessage:unlink()
  */
 int l_CMessage_unlink(lua_State * l)
 {
@@ -478,6 +494,23 @@ int l_CMessage_unlink(lua_State * l)
     global->update_messages();
 
     return 0;
+}
+
+/**
+ * Implementation for CMessage:needs_gpg()
+ */
+int l_CMessage_need_gpg(lua_State * l)
+{
+    CLuaLog("l_CMessage_needs_gpg");
+
+    std::shared_ptr<CMessage> msg = l_CheckCMessage(l, 1);
+
+    if (msg)
+        lua_pushboolean(l , msg->need_gpg());
+    else
+        lua_pushboolean(l , 0);
+
+    return 1;
 }
 
 /**
@@ -502,7 +535,9 @@ void InitMessage(lua_State * l)
         {"new", l_CMessage_constructor},
         {"parts", l_CMessage_parts},
         {"path", l_CMessage_path},
+        {"replace", l_CMessage_replace},
         {"unlink", l_CMessage_unlink},
+        {"need_gpg", l_CMessage_need_gpg},
         {NULL, NULL}
     };
     luaL_newmetatable(l, "luaL_CMessage");

--- a/src/message_part.cc
+++ b/src/message_part.cc
@@ -37,6 +37,7 @@ CMessagePart::CMessagePart(std::string type, std::string filename,
     m_filename       = filename;
     m_content        = NULL;
     m_content_length = 0;
+    m_need_gpg       = false;
 
     if ((content_length > 0) && (content != NULL))
     {

--- a/src/message_part.h
+++ b/src/message_part.h
@@ -87,6 +87,16 @@ public:
      */
     std::shared_ptr<CMessagePart> get_parent();
 
+    /**
+     * Does this part need gpg ?
+     */
+    bool need_gpg() { return m_need_gpg; }
+
+    /**
+     * Set m_need_gpg
+     */
+    void need_gpg(bool b) {  m_need_gpg = b; }
+
 
 private:
 
@@ -120,4 +130,9 @@ private:
      * Parent of this part.
      */
     std::shared_ptr<CMessagePart> m_parent;
+
+    /**
+     * Is this part a signature or encrypted  ?
+     */
+    bool m_need_gpg;
 };


### PR DESCRIPTION
This addresses #298.

All messages now store if they need gpg interaction to be usable.
The functions `CMessage:need_gpg()` in C++ and `Message:need_gpg()` in Lua
can be used to retrieve this information.

`message_view()` replaces the content of the opened message with a temporary
file returned by `GPG.decrypt()` if needed.

The message flags in `index_mode()` now show a 'G' if the message is either
signed or encrypted instead of 'S'.

I came up with this solution because it's simple and doesn't change much code.

**Changed Behaviour**

* Opening my INBOX threaded with ~780 messages and ~80 "gpg messages" now takes 2s instead of 10s.
* After this change the user has to call `GPG.decrypt()` explicitly when he wants to use gpg encrypted mails outside of `message_view()`.

You can test this by overwriting `_G["message_replace"] = nil` in your user config.

