### PR TITLE
[WPI] Improve gpg v2

### DIFF
--- a/src/message.h
+++ b/src/message.h
@@ -207,6 +207,11 @@ private:
     GMimeMessage * parse_message();
 
     /**
+     * Populate the headers and MIME-Parts caches.
+     */
+    void populate_message();
+
+    /**
      * Convert a message-part from the MIME message to a CMessagePart object.
      */
     std::shared_ptr<CMessagePart> part2obj(GMimeObject *part);

--- a/src/message.h
+++ b/src/message.h
@@ -16,9 +16,7 @@
  * General Public License can be found in `/usr/share/common-licenses/GPL-2'
  */
 
-
 #pragma once
-
 
 #include <memory>
 #include <string>
@@ -32,8 +30,6 @@ class CMaildir;
  * Forward declaration of class.
  */
 class CMessagePart;
-
-
 
 /**
  *
@@ -60,12 +56,10 @@ public:
      */
     bool is_maildir();
 
-
     /**
      * Is this message an IMAP one?
      */
     bool is_imap();
-
 
     /**
       * Get the path of this message.
@@ -109,7 +103,6 @@ public:
     {
         m_imap_id = n;
     };
-
 
     /**
      * Add a flag to a message.
@@ -163,7 +156,6 @@ public:
      */
     std::vector<std::shared_ptr<CMessagePart>> get_parts();
 
-
     /**
      * Add the named file as an attachment to this message.
      */
@@ -177,7 +169,6 @@ public:
      * the message.
      */
     std::shared_ptr<CMaildir> parent();
-
 
     /**
      * Set the parent object - this is only used for IMAP-based messages.
@@ -193,6 +184,11 @@ public:
      */
     int get_mtime();
 
+    /**
+     * Populate the headers and MIME-Parts caches.
+     */
+    void populate_message(int fd);
+
 private:
 
     /**
@@ -202,14 +198,9 @@ private:
 
     /**
      * Parse a MIME message and return an object suitable for operating
-     * upon.
+     * upon. If fd is less than 2 m_path is used to find the message.
      */
-    GMimeMessage * parse_message();
-
-    /**
-     * Populate the headers and MIME-Parts caches.
-     */
-    void populate_message();
+    GMimeMessage * parse_message(int fd);
 
     /**
      * Convert a message-part from the MIME message to a CMessagePart object.
@@ -258,8 +249,6 @@ private:
      */
     std::shared_ptr<CMaildir> m_parent;
 };
-
-
 
 /**
  * This is a utility-type which contains a list of messages, as

--- a/src/message_lua.cc
+++ b/src/message_lua.cc
@@ -98,7 +98,7 @@ void push_cmessage(lua_State * l, std::shared_ptr<CMessage> message)
 }
 
 /**
- * Implementation for Message.new
+ * Implementation for Message.new()
  */
 int l_CMessage_constructor(lua_State * l)
 {
@@ -148,6 +148,27 @@ int l_CMessage_path(lua_State * l)
     return 1;
 }
 
+/**
+ * Implementation for Message:replace()
+ *
+ * Reread message from file.
+ */
+int l_CMessage_replace(lua_State * l)
+{
+    CLuaLog("l_CMessage_replace");
+
+    std::shared_ptr<CMessage> msg = l_CheckCMessage(l, 1);
+    if (msg)
+    {
+        /* Get file from lua */
+        FILE *f = *(FILE**) luaL_checkudata(l, 2, LUA_FILEHANDLE);
+        const int fd = fileno(f);
+
+        /* Reread message */
+        msg->populate_message(fd);
+    }
+    return 0;
+}
 
 /**
  * Implementation for Message:generate_message_id()
@@ -178,7 +199,6 @@ int l_CMessage_generate_message_id(lua_State *L)
     return 1;
 
 }
-
 
 /**
  * Implementation for Message:header()
@@ -237,7 +257,6 @@ int l_CMessage_headers(lua_State * l)
     return (1);
 }
 
-
 /**
  * Implementation for Message:mark_read()
  */
@@ -262,7 +281,6 @@ int l_CMessage_mark_unread(lua_State *l)
     return 0;
 }
 
-
 /**
  * Implementation for Message:mtime()
  */
@@ -276,7 +294,6 @@ int l_CMessage_mtime(lua_State *l)
     lua_pushnumber(l, m_time);
     return 1;
 }
-
 
 /**
  * Implementation for Message:parts()
@@ -313,9 +330,8 @@ int l_CMessage_parts(lua_State * l)
     return 1;
 }
 
-
 /**
- * Implementation of CMessage:add_attachments
+ * Implementation for CMessage:add_attachments()
  */
 int l_CMessage_add_attachments(lua_State * l)
 {
@@ -348,9 +364,8 @@ int l_CMessage_add_attachments(lua_State * l)
     return 0;
 }
 
-
 /**
- * Implementation of CMessage:ctime()
+ * Implementation for CMessage:ctime()
  */
 int l_CMessage_ctime(lua_State * l)
 {
@@ -384,9 +399,8 @@ int l_CMessage_ctime(lua_State * l)
     return 1;
 }
 
-
 /**
- * Implementation of CMessage:flags
+ * Implementation for CMessage:flags()
  */
 int l_CMessage_flags(lua_State * l)
 {
@@ -433,7 +447,6 @@ int l_CMessage_destructor(lua_State * l)
     return 0;
 }
 
-
 /**
  * Equality-test - this is bound to the Lua meta-method `__eq` such that two
  * messages may be tested for equality.
@@ -456,9 +469,8 @@ int l_CMessage_equality(lua_State * l)
     return 1;
 }
 
-
 /**
- * Implementation of CMessage:unlink
+ * Implementation for CMessage:unlink()
  */
 int l_CMessage_unlink(lua_State * l)
 {
@@ -502,6 +514,7 @@ void InitMessage(lua_State * l)
         {"new", l_CMessage_constructor},
         {"parts", l_CMessage_parts},
         {"path", l_CMessage_path},
+        {"replace", l_CMessage_replace},
         {"unlink", l_CMessage_unlink},
         {NULL, NULL}
     };


### PR DESCRIPTION
The first commit reduces the amount of `parse_message` invocations from two to one.

And the second commit adds `Message:replace` to replace a message with the content of a file on demand.

This changes no current behaviour! And is sufficient for my needs. I can use something like:

```lua
-- disable our decryption
_G["replace_message"] = nil

do
  local _message_view = message_view
  message_view = function(msg)
    -- check if we need gpg
    if msg:contains("PGP") then
      msg:replace(io.popen("mimegpgp ..."))
    end
  end
  return _message_view(msg)
end
```
in my config to decrypt messages only if I use their content with `message_view`.

What do you thing should be the default behaviour ?
Do you want to keep `message_replace` and the approach with a temporary file ?

**Additional thoughts:**

* Disabling `message_replace` could break the setup of someone using lumail as a framework. Don't know if someone actually does that.
* Keeping `message_replace` and remodel it to something like `Message:replace` will result in a really awkward interface.

