### PR TITLE
Cleanup

### DIFF
--- a/global.config.lua
+++ b/global.config.lua
@@ -397,12 +397,14 @@ function Config.key_changed (name, old)
 
   --
   -- If the sorting method has changed we need to resort our messages.
+  -- But only If we are in index view. Otherwise the messages get resorted when
+  -- index view is selected.
   --
   -- NOTE: We explicitly avoid re-reading the maildir, so we're
   -- just changing the order of the existing messages not refreshing
   -- them 100%.
   --
-  if name == "index.sort" then
+  if name == "index.sort" and Config:get "global.mode" == "index" then
     global_msgs = sort_messages(global_msgs)
     return
   end

--- a/global.config.lua
+++ b/global.config.lua
@@ -92,21 +92,17 @@ GPG = nil
 if string.path "mimegpg" then
   GPG = require "gpg"
 end
-Panel:append(GPG)
-
 
 --
 -- Setup a cache for objects.
 --
 cache = Cache.new()
 
-
 --
 -- If the user changes the index-limit we'll try to keep the same
 -- maildir selected.  We do that by caching the old value here.
 --
 local prev_maildir = nil
-
 
 --
 -- This contains the messages which are currently visible.

--- a/lib/threader.lua
+++ b/lib/threader.lua
@@ -28,6 +28,7 @@
 --      local threads = Threader.thread(messages)
 --
 
+Progress = require "progress_bar"
 require "table_utilities"
 
 --
@@ -308,6 +309,7 @@ function Threader.thread (messages)
 
   -- 1:
   for _, msg in ipairs(messages) do
+    Progress:step("sorting messages")
 
     -- 1.A: create/get container of the current message
     local msgid = msg:header "Message-ID"
@@ -360,6 +362,7 @@ function Threader.thread (messages)
 
   -- 2: find root set
   for _, v in pairs(id_table) do
+    Progress:step("sorting messages")
     if v.parent == nil then
       table.insert(roots, v)
     end
@@ -381,6 +384,7 @@ function Threader.thread (messages)
   -- 5.B: find subject of this tree
   local without_subject = {}
   for _, root in ipairs(roots) do
+    Progress:step("sorting messages")
 
     local subject = root:get_normalized_subject()
     if subject ~= "" then
@@ -397,6 +401,7 @@ function Threader.thread (messages)
   -- Prefer non-replies, older than any child of the empty container, over
   -- the empty container
   for _, root in ipairs(roots) do
+    Progress:step("sorting messages")
     local subject = root:get_normalized_subject()
     local target = subject_table[subject]
     if target and target ~= root then


### PR DESCRIPTION
During my work on the header cache (#342) I collected a set of small not related changes.

* Avoid double resort when the value of "index.sort" changes
* Remove a debugging leftover
* Use the progress bar during thread sort