### PR TITLE
add interactive string search to CScreen::choose_string

### DIFF
--- a/src/screen.cc
+++ b/src/screen.cc
@@ -710,7 +710,7 @@ std::string CScreen::choose_string(std::vector<std::string> choices)
         /*
          * If the selection is bigger than the matches select the last item.
          */
-        if ((size_t)selected > matches.size())
+        if ((size_t)selected >= matches.size())
             selected = matches.size()-1;
 
         int count = 0;
@@ -814,8 +814,11 @@ std::string CScreen::choose_string(std::vector<std::string> choices)
          */
         if (c == KEY_BACKSPACE || isprint(c))
         {
-            if (c == KEY_BACKSPACE && search_string.length() > 0)
-                search_string.pop_back();
+            if (c == KEY_BACKSPACE)
+                if (search_string.length() > 0)
+                    search_string.pop_back();
+                else
+                    beep();
             else
                 search_string += c;
 

--- a/src/screen.cc
+++ b/src/screen.cc
@@ -743,7 +743,7 @@ std::string CScreen::choose_string(std::vector<std::string> choices)
          * Display the search string in the last line.
          */
         if (search_string != "") {
-            mvwprintw(childwin, height - 1, 1, "%s %s", "search:", search_string.c_str());
+            mvwprintw(childwin, height - 1, 1, "%s %s ", "filter:", search_string.c_str());
         }
 
         wrefresh(childwin);


### PR DESCRIPTION
If the user types printable characters they are added to a search string
and only completion candidates containing the search string are displayed.

The current search string gets printed in the bottom boarder of the window.

I wanted this for email completions maybe its usefull for others too.
It works for all kind of completions and doesn't change current behaviour.