### PR TITLE
Implement Screen:execute() variant which returns stdout

### DIFF
--- a/src/screen.cc
+++ b/src/screen.cc
@@ -17,8 +17,12 @@
  */
 
 #include <algorithm>
+#include <array>
+#include <cstdio>
 #include <fstream>
 #include <iostream>
+#include <memory>
+#include <stdexcept>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
@@ -411,6 +415,30 @@ void CScreen::execute(std::string prog)
      */
     reset_prog_mode();
     refresh();
+}
+
+/*
+ * Execute a command via `system`.
+ *
+ * This variant returns the `stdout` of the command run
+ */
+std::string CScreen::execute_read_stdout(std::string program)
+{
+    std::array<char, 128>   buffer;
+    std::string             result;
+    std::shared_ptr<FILE>   pipe(popen(program.c_str(), "r"), pclose);
+
+    if (!pipe) {
+        throw std::runtime_error("popen() failed!");
+    }
+
+    while (!feof(pipe.get())) {
+        if (fgets(buffer.data(), 128, pipe.get()) != nullptr) {
+            result += buffer.data();
+        }
+    }
+
+    return result;
 }
 
 /*

--- a/src/screen.h
+++ b/src/screen.h
@@ -204,6 +204,13 @@ public:
     void execute(std::string program);
 
     /**
+     * Execute a program, resetting the screen first.
+     *
+     * This variant returns the `stdout` of the command run.
+     */
+    std::string execute_read_stdout(std::string program);
+
+    /**
      * Is the given character a multi-key prefix?
      */
     bool is_prefixed_key(const char *key);

--- a/src/screen_lua.cc
+++ b/src/screen_lua.cc
@@ -91,6 +91,27 @@ int l_CScreen_execute(lua_State *l)
 
 }
 
+/**
+ * Implementation of Screen:execute_read_stdout().
+ *
+ * Returns the string on success, on error reading stdout it returns nil.
+ */
+int l_CScreen_execute_read_stdout(lua_State *l)
+{
+    CLuaLog("l_CScreen_execute_read_stdout");
+    const char *prog = luaL_checkstring(l, 2);
+
+    CScreen *foo = CScreen::instance();
+
+    try {
+        std::string output = foo->execute_read_stdout(prog);
+        lua_pushstring(l, output.c_str());
+    } catch (std::runtime_error& e) {
+        lua_pushnil(l);
+    }
+
+    return 0;
+}
 
 /**
  * Implementation of Screen:exit().
@@ -277,6 +298,7 @@ void InitScreen(lua_State * l)
         {"clear", l_CScreen_clear},
         {"draw", l_CScreen_draw},
         {"execute",  l_CScreen_execute},
+        {"execute_read_stdout",  l_CScreen_execute_read_stdout},
         {"exit",  l_CScreen_exit},
         {"get_char", l_CScreen_get_char},
         {"get_line", l_CScreen_get_line},


### PR DESCRIPTION
I started development of a contact book integration for my lumail setup and found that this is missing.

I know there is `os.execute()` but when doing `os.execute("echo -e '1\n2' | fzf")` this still trashes the terminal and lumail is unusable after that.

So I started to implement a `Screen:execute()` variant which returns stdout. Unfortunately *this does not yet work as intended* because the return value is not put on the lua stack properly, I don't know why.

Tested with

```
Panel:append(tostring(Screen:execute_read_stdout("echo 1")))
```

Feedback and help much appreciated!