### PR TITLE
send utf-8 encoding header

### DIFF
--- a/global.config.lua
+++ b/global.config.lua
@@ -1119,6 +1119,7 @@ From: ${from}
 Subject: ${subject}
 Message-ID: ${msgid}
 Date: ${date}
+Content-Type: text/plain; charset="utf-8"
 
 ${sig}
 ]]
@@ -1392,6 +1393,7 @@ Date: ${date}
 Message-ID: ${msgid}
 In-Reply-To: ${source_id}
 References: ${references}
+Content-Type: text/plain; charset="utf-8"
 
 ]]
 
@@ -1717,6 +1719,7 @@ From: ${from}
 Subject: Fwd: ${subject}
 Message-ID: ${msgid}
 Date: ${date}
+Content-Type: text/plain; charset="utf-8"
 
 Begin forwarded message.
 


### PR DESCRIPTION
Other email clients (only tested with thunderbird 52.8.0) have problems
with some utf8 runes (only tested with german umlauts) if the utf8 context
header is not added to the message prototype.

An encoding header is only missing if we don't use gmime to add another
mime part. If we add another mime part gmime maybe ignores our header or
is smart enough to use it. I can't see a difference in messages with
an attachment before and after this change.

![2018-05-23-011000_1920x1080_scrot](https://user-images.githubusercontent.com/1218430/40395346-d82decc0-5e27-11e8-9345-e6152fb92af6.png)

**Thunderbird on the right**: A message send with lumail before the change.
**Lumail on the left**: A response send from thunderbird conatining new umlauts. There we see the
corrupted runes in the quoted text.

I think this happens because thunderbird fallbacks to some other encoding than we actually send.
@skx **I don't know if we acutally send utf-8. Do you think setting this header
is not correct ? I tried it and it works somehow.**
