### PR TITLE
Some random fixes

### DIFF
--- a/perl.d/Lumail.pm
+++ b/perl.d/Lumail.pm
@@ -64,6 +64,7 @@ sub imap_connect
         $host = $1;
         $ssl  = 0;
     }
+    die "No imap_server specified." unless $1;
 
     my $handle = Net::IMAP::Client->new(
         server          => $host,

--- a/perl.d/imap-proxy
+++ b/perl.d/imap-proxy
@@ -125,9 +125,11 @@ while (1)
     #
     #  Send a "still alive" message to our remote IMAP-server.
     #
-    $handle->noop();
-
-    if ( !$handle )
+    if ( $handle )
+    {
+        $handle->noop();
+    }
+    else
     {
         $handle = Lumail::imap_connect();
     }

--- a/src/global_state.cc
+++ b/src/global_state.cc
@@ -272,7 +272,7 @@ void CGlobalState::update_maildirs()
         if (!parsingSuccessful)
         {
             CLua *lua = CLua::instance();
-            lua->on_error("Failed to parse JSON response to 'list_folders'.");
+            lua->on_error("Failed to parse JSON response to 'list_folders': " + json);
 
             config->set("maildir.max", 0);
             return;

--- a/src/imap_proxy.cc
+++ b/src/imap_proxy.cc
@@ -99,6 +99,7 @@ void CIMAPProxy::launch()
             if (m_child == 0)
             {
                 unused = execl(path.c_str(), CFile::basename(path).c_str(), NULL);
+                exit(1);
             }
 
             sleep(1.0);

--- a/src/imap_proxy.h
+++ b/src/imap_proxy.h
@@ -64,4 +64,9 @@ private:
      * The handle to our child-process.
      */
     pid_t m_child;
+
+    /**
+     * Path to the IMAP proxy socket.
+     */
+    std::string m_sock_path;
 };


### PR DESCRIPTION
Here's a fairly random collection of changes I chose to make when making Lumail work for me.

The only real fix there is the removal of the 1 second wait on spawning the IMAP helper, since that is too short for some of my machines (oh the lovely OLPC laptop); while perhaps being unnecessarily long for others. It probably deserves a better fix anyway though; but this seems to work well for now.