### PR TITLE
Allow oneshots with tui

### DIFF
--- a/global.config.lua
+++ b/global.config.lua
@@ -1090,14 +1090,14 @@ end
 --
 -- Compose a new message.
 --
-function Message.compose ()
+function Message.compose (to, subject)
 
   -- Get some details
-  local to = Screen:get_address "To:"
+  local to = to or Screen:get_address "To:"
   if to == nil or to == "" then
     return
   end
-  local subject = Screen:get_line "Subject:"
+  local subject = subject or Screen:get_line "Subject:"
   if subject == nil or subject == "" then
     subject = "No subject"
   end

--- a/sample.lua/compose.lua
+++ b/sample.lua/compose.lua
@@ -1,0 +1,18 @@
+--
+--
+-- Usage:
+--
+--     lumail2 --load-file ./compose.lua --to=email@address.tld --subj=
+--
+
+-- Iterate over the command-line arguments
+--
+local recipient, subject
+for i, v in ipairs(ARGS) do
+  recipient = string.match(v, "--to=(.*)")
+  subject = string.match(v, "--subj=(.*)")
+end
+
+Message.compose(recipient, subject)
+os.exit(0)
+

--- a/src/screen.cc
+++ b/src/screen.cc
@@ -140,11 +140,6 @@ void CScreen::update(std::string key_name, CConfigEntry *old)
 void CScreen::run_main_loop()
 {
     /*
-     * Now we're in our loop.
-     */
-    m_running = true;
-
-    /*
      * Get the lua-helper.
      */
     CLua *lua = CLua::instance();

--- a/src/screen.h
+++ b/src/screen.h
@@ -255,7 +255,7 @@ private:
     /**
      * Are we (still) in the event-loop?
      */
-    bool m_running;
+    bool m_running = true;
 
     /**
      * This map contains a mapping between a given mode-name and the


### PR DESCRIPTION
Those changes allow files loaded with `--load-file` to call `os.exit` and prevent the main loop from running.

See the commit messages for further explanaition and an useful example.